### PR TITLE
Filter matches based on BeginTime.

### DIFF
--- a/cachedclient/cachedclient.go
+++ b/cachedclient/cachedclient.go
@@ -189,6 +189,10 @@ func filterMatchlist(m *apiclient.Matchlist, opts *apiclient.GetMatchlistOptions
 			if opts.EndTime.Before(ts) {
 				continue
 			}
+		} else if opts.BeginTime != nil {
+			if opts.BeginTime.After(ts) {
+				continue
+			}
 		}
 
 		if opts.BeginIndex == nil && opts.EndIndex != nil {


### PR DESCRIPTION
Previously, cached client only handled cases where both BeginTime and
EndTime were provided, or only EndTime was provided.