### PR TITLE
Make Champion Struct BigQuery Friendly

### DIFF
--- a/staticdata/champions.go
+++ b/staticdata/champions.go
@@ -69,7 +69,7 @@ type ChampionStats struct {
 type ChampionSkin struct {
 	Num  int
 	Name string
-	Id   int
+	Id   string
 }
 
 type ChampionPassive struct {
@@ -97,7 +97,7 @@ type ChampionBlock struct {
 
 type ChampionBlockItem struct {
 	Count int
-	Id    int
+	Id    string
 }
 
 // RangeOrSelf represents either an ability that targets self, or an ability
@@ -168,7 +168,7 @@ type SpellVars struct {
 	RanksWith string
 	Dyn       string
 	Link      string
-	Coeff     []float64
+	Coeff     float64
 	Key       string
 }
 

--- a/staticdata/champions.go
+++ b/staticdata/champions.go
@@ -136,7 +136,7 @@ type ChampionSpell struct {
 	Image                Image
 	SanitizedDescription string
 	SanitizedTooltip     string
-	Effect               [][]float64
+	Effect               []SpellEffect
 	Tooltip              string
 	Maxrank              int
 	CostBurn             string
@@ -149,6 +149,14 @@ type ChampionSpell struct {
 	EffectBurn           []string
 	Altimages            []Image
 	Name                 string
+}
+
+type SpellEffect struct {
+	Details []float64
+}
+
+func (s *SpellEffect) UnmarshalJSON(b []byte) error {
+	return json.Unmarshal(b, &s.Details)
 }
 
 type SpellLevelTip struct {


### PR DESCRIPTION
The motivation for this PR was that the old static champion data structure couldn't get stored in BigQuery. It had a field of type [][]float, and BigQuery doesn't support nested slices. Since the library is generally designed to work with Google Cloud, I figured it was reasonable to make a change to ensure compatibility.

While making that change, I discovered that a few of the fields in the struct were typed wrong, so I fixed those as well.