### PR TITLE
Changed max date so that durations will be distinct

### DIFF
--- a/cachedclient/google/google.go
+++ b/cachedclient/google/google.go
@@ -22,7 +22,7 @@ var (
 	// in time until terminalTime. In principle, we could store values descending
 	// in time to get the most recent observation, but this requires additional
 	// index configuration.
-	terminalTime = time.Date(2500, time.December, 0, 0, 0, 0, 0, time.UTC)
+	terminalTime = time.Date(2300, time.December, 0, 0, 0, 0, 0, time.UTC)
 )
 
 type googleDatastore struct {


### PR DESCRIPTION
Previously, the difference between the max date and the present date was larger than the maximum Duration that Go can represent, so everything was getting the same timestamp. Duration can represent up to ~290 years, and 2300 is the largest round year that's less than 290 years away from the present.