### PR TITLE
Added queuetype to LeaguePosition

### DIFF
--- a/apiclient/league.go
+++ b/apiclient/league.go
@@ -40,6 +40,7 @@ type MiniSeries struct {
 
 type LeaguePosition struct {
 	Rank             string     `datastore:",noindex"`
+	QueueType        string     `datastore:",noindex"`
 	HotStreak        bool       `datastore:",noindex"`
 	MiniSeries       MiniSeries `datastore:",noindex"`
 	Wins             int        `datastore:",noindex"`


### PR DESCRIPTION
As it stands, users would need to do unnecessary api calls to GetLeagueByID just to find out the queue type for the leagues returned from GetAllLeaguePositionsForSummoner. This should alleviate that issue.