### PR TITLE
Add RequiredAlly field

### DIFF
--- a/staticdata/items.go
+++ b/staticdata/items.go
@@ -36,6 +36,7 @@ type Item struct {
 	Tags                 []string
 	Effect               map[string]string
 	RequiredChampion     string
+	RequiredAlly         string
 	From                 []string
 	Group                string
 	ConsumeOnFull        bool


### PR DESCRIPTION
I imagine Riot added this field as a hack when they introduced Ornn. I know this is a minor change but it makes it a lot easier to filter items.