### PR TITLE
Update mid lane constant

### DIFF
--- a/constants/lane/lane.go
+++ b/constants/lane/lane.go
@@ -5,7 +5,7 @@ type Lane string
 type Type string
 
 const (
-	Middle Lane = "MIDDLE"
+	Middle Lane = "MID"
 	Top         = "TOP"
 	Jungle      = "JUNGLE"
 	Bottom      = "BOTTOM"


### PR DESCRIPTION
The matchlist API uses `"MID"` as a constant in responses rather than `"MIDDLE"` as can be seen [here.](https://developer.riotgames.com/api-methods/#match-v3/GET_getMatchlist)