### PR TITLE
Replace v3 endpoints with v4

### DIFF
--- a/analytics/data_aggregation/data_aggregation.go
+++ b/analytics/data_aggregation/data_aggregation.go
@@ -120,7 +120,7 @@ func (a Aggregator) GetMatchIDsForAccounts(ctx context.Context, r region.Region,
 					}
 				}
 			} else {
-				log.Printf("GetMatchlist failed for region %s account %d: %v", r, account, err)
+				log.Printf("GetMatchlist failed for region %s account %s: %v", r, account, err)
 			}
 		}()
 	}
@@ -198,7 +198,7 @@ func (a Aggregator) getAccountIDsInLeague(ctx context.Context, r region.Region, 
 			defer wg.Done()
 			summoner, err := a.client.GetBySummonerID(ctx, r, entry.PlayerOrTeamID)
 			if err != nil {
-				log.Printf("GetBySummonerID failed for region %s summoner %d: %v", r, entry.PlayerOrTeamID, err)
+				log.Printf("GetBySummonerID failed for region %s summoner %s: %v", r, entry.PlayerOrTeamID, err)
 				return
 			}
 			select {

--- a/apiclient/apiclient.go
+++ b/apiclient/apiclient.go
@@ -50,7 +50,7 @@ type Client interface {
 	GetChallengerLeague(context.Context, region.Region, queue.Queue) (*LeagueList, error)
 
 	// GetGrandmasterLeague returns the grandmaster league for the given queue.
-	GetGrandmasterLeague(ctx context.Context, r region.Region, q queue.Queue)
+	GetGrandmasterLeague(ctx context.Context, r region.Region, q queue.Queue) (*LeagueList, error)
 
 	// GetMasterLeague returns the master league for the given queue.
 	GetMasterLeague(context.Context, region.Region, queue.Queue) (*LeagueList, error)

--- a/apiclient/apiclient.go
+++ b/apiclient/apiclient.go
@@ -27,14 +27,14 @@ type Client interface {
 
 	// GetAllChampionMasteries returns all champion mastery entries sorted by
 	// number of champion points descending.
-	GetAllChampionMasteries(ctx context.Context, r region.Region, summonerID int64) ([]ChampionMastery, error)
+	GetAllChampionMasteries(ctx context.Context, r region.Region, summonerID string) ([]ChampionMastery, error)
 
 	// GetChampionMastery returns champion mastery by summoner ID and champion.
-	GetChampionMastery(ctx context.Context, r region.Region, summonerID int64, champ champion.Champion) (*ChampionMastery, error)
+	GetChampionMastery(ctx context.Context, r region.Region, summonerID string, champ champion.Champion) (*ChampionMastery, error)
 
 	// GetChampionMasteryScore returns a player's total champion mastery score,
 	// which is the sum of individual champion mastery levels.
-	GetChampionMasteryScore(ctx context.Context, r region.Region, summonerID int64) (int, error)
+	GetChampionMasteryScore(ctx context.Context, r region.Region, summonerID string) (int, error)
 
 	// ----- Champions API -----
 
@@ -54,7 +54,7 @@ type Client interface {
 
 	// GetAllLeaguePositionsForSummoner returns league positions in all queues
 	// for the given summoner ID.
-	GetAllLeaguePositionsForSummoner(ctx context.Context, r region.Region, summonerID int64) ([]LeaguePosition, error)
+	GetAllLeaguePositionsForSummoner(ctx context.Context, r region.Region, summonerID string) ([]LeaguePosition, error)
 
 	// GetLeagueByID returns the league with given ID, including inactive
 	// entries.
@@ -69,10 +69,10 @@ type Client interface {
 
 	// GetMatchlist returns a matchlist for games played on a given account ID
 	// and filtered using given filter parameters, if any.
-	GetMatchlist(ctx context.Context, r region.Region, accountID int64, opts *GetMatchlistOptions) (*Matchlist, error)
+	GetMatchlist(ctx context.Context, r region.Region, accountID string, opts *GetMatchlistOptions) (*Matchlist, error)
 
 	// GetRecentMatchlist returns the last 20 matches played on the given account ID.
-	GetRecentMatchlist(ctx context.Context, r region.Region, accountID int64) (*Matchlist, error)
+	GetRecentMatchlist(ctx context.Context, r region.Region, accountID string) (*Matchlist, error)
 
 	// ----- Spectator API -----
 
@@ -81,23 +81,23 @@ type Client interface {
 
 	// GetCurrentGameInfoBySummoner returns current game information for a given
 	// summoner ID.
-	GetCurrentGameInfoBySummoner(ctx context.Context, r region.Region, summonerID int64) (*CurrentGameInfo, error)
+	GetCurrentGameInfoBySummoner(ctx context.Context, r region.Region, summonerID string) (*CurrentGameInfo, error)
 
 	// ----- Summoner API -----
 
 	// GetByAccountID returns a summoner by account ID.
-	GetByAccountID(ctx context.Context, r region.Region, accountID int64) (*Summoner, error)
+	GetByAccountID(ctx context.Context, r region.Region, accountID string) (*Summoner, error)
 
 	// GetBySummonerName returns a summoner by summoner name.
 	GetBySummonerName(ctx context.Context, r region.Region, name string) (*Summoner, error)
 
 	// GetBySummonerID returns a sumoner by summoner ID.
-	GetBySummonerID(ctx context.Context, r region.Region, summonerID int64) (*Summoner, error)
+	GetBySummonerID(ctx context.Context, r region.Region, summonerID string) (*Summoner, error)
 
 	// ----- Third Party Code API -----
 
 	// GetThirdPartyCodeByID returns a string set by the given summoner
-	GetThirdPartyCodeByID(ctx context.Context, r region.Region, summonerID int64) (string, error)
+	GetThirdPartyCodeByID(ctx context.Context, r region.Region, summonerID string) (string, error)
 }
 
 // client is the internal implementation of Client.

--- a/apiclient/apiclient.go
+++ b/apiclient/apiclient.go
@@ -91,6 +91,9 @@ type Client interface {
 	// GetBySummonerName returns a summoner by summoner name.
 	GetBySummonerName(ctx context.Context, r region.Region, name string) (*Summoner, error)
 
+	// GetBySummonerPUUID returns a summoner by PUUID.
+	GetBySummonerPUUID(ctx context.Context, r region.Region, puuid string) (*Summoner, error)
+
 	// GetBySummonerID returns a sumoner by summoner ID.
 	GetBySummonerID(ctx context.Context, r region.Region, summonerID string) (*Summoner, error)
 

--- a/apiclient/apiclient.go
+++ b/apiclient/apiclient.go
@@ -49,6 +49,9 @@ type Client interface {
 	// GetChallengerLeague returns the challenger league for the given queue.
 	GetChallengerLeague(context.Context, region.Region, queue.Queue) (*LeagueList, error)
 
+	// GetGrandmasterLeague returns the grandmaster league for the given queue.
+	GetGrandmasterLeague(ctx context.Context, r region.Region, q queue.Queue)
+
 	// GetMasterLeague returns the master league for the given queue.
 	GetMasterLeague(context.Context, region.Region, queue.Queue) (*LeagueList, error)
 

--- a/apiclient/champion_mastery.go
+++ b/apiclient/champion_mastery.go
@@ -13,26 +13,26 @@ type ChampionMastery struct {
 	ChampionLevel                int               `datastore:",noindex"` // Champion level for specified player and champion combination.
 	ChampionPoints               int               `datastore:",noindex"` // Total number of champion points for this player and champion combination - they are used to determine championLevel.
 	ChampionID                   champion.Champion `datastore:",noindex"` // Champion ID for this entry.
-	PlayerID                     int64             `datastore:",noindex"` // Player ID for this entry.
+	PlayerID                     string            `datastore:",noindex"` // Encrypted Player ID for this entry.
 	ChampionPointsUntilNextLevel int64             `datastore:",noindex"` // Number of points needed to achieve next level. Zero if player reached maximum champion level for this champion.
 	ChampionPointsSinceLastLevel int64             `datastore:",noindex"` // Number of points earned since current level has been achieved. Zero if player reached maximum champion level for this champion.
 	LastPlayTime                 int64             `datastore:",noindex"` // Last time this champion was played by this player - in Unix milliseconds time format.
 }
 
-func (c *client) GetAllChampionMasteries(ctx context.Context, r region.Region, summonerID int64) ([]ChampionMastery, error) {
+func (c *client) GetAllChampionMasteries(ctx context.Context, r region.Region, summonerID string) ([]ChampionMastery, error) {
 	var res []ChampionMastery
-	_, err := c.dispatchAndUnmarshal(ctx, r, "/lol/champion-mastery/v3/champion-masteries/by-summoner", fmt.Sprintf("/%d", summonerID), nil, &res)
+	_, err := c.dispatchAndUnmarshal(ctx, r, "/lol/champion-mastery/v4/champion-masteries/by-summoner", fmt.Sprintf("/%s", summonerID), nil, &res)
 	return res, err
 }
 
-func (c *client) GetChampionMastery(ctx context.Context, r region.Region, summonerID int64, champ champion.Champion) (*ChampionMastery, error) {
+func (c *client) GetChampionMastery(ctx context.Context, r region.Region, summonerID string, champ champion.Champion) (*ChampionMastery, error) {
 	var res ChampionMastery
-	_, err := c.dispatchAndUnmarshalWithUniquifier(ctx, r, "/lol/champion-mastery/v3/champion-masteries/by-summoner", fmt.Sprintf("/%d/by-champion/%d", summonerID, champ), nil, "by-champion", &res)
+	_, err := c.dispatchAndUnmarshalWithUniquifier(ctx, r, "/lol/champion-mastery/v4/champion-masteries/by-summoner", fmt.Sprintf("/%s/by-champion/%d", summonerID, champ), nil, "by-champion", &res)
 	return &res, err
 }
 
-func (c *client) GetChampionMasteryScore(ctx context.Context, r region.Region, summonerID int64) (int, error) {
+func (c *client) GetChampionMasteryScore(ctx context.Context, r region.Region, summonerID string) (int, error) {
 	var res int
-	_, err := c.dispatchAndUnmarshal(ctx, r, "/lol/champion-mastery/v3/scores/by-summoner", fmt.Sprintf("/%d", summonerID), nil, &res)
+	_, err := c.dispatchAndUnmarshal(ctx, r, "/lol/champion-mastery/v4/scores/by-summoner", fmt.Sprintf("/%s", summonerID), nil, &res)
 	return res, err
 }

--- a/apiclient/league.go
+++ b/apiclient/league.go
@@ -57,24 +57,24 @@ type LeaguePosition struct {
 
 func (c *client) GetChallengerLeague(ctx context.Context, r region.Region, q queue.Queue) (*LeagueList, error) {
 	var res LeagueList
-	_, err := c.dispatchAndUnmarshal(ctx, r, "/lol/league/v3/challengerleagues/by-queue", fmt.Sprintf("/%s", q.String()), nil, &res)
+	_, err := c.dispatchAndUnmarshal(ctx, r, "/lol/league/v4/challengerleagues/by-queue", fmt.Sprintf("/%s", q.String()), nil, &res)
 	return &res, err
 }
 
 func (c *client) GetMasterLeague(ctx context.Context, r region.Region, q queue.Queue) (*LeagueList, error) {
 	var res LeagueList
-	_, err := c.dispatchAndUnmarshal(ctx, r, "/lol/league/v3/masterleagues/by-queue", fmt.Sprintf("/%s", q.String()), nil, &res)
+	_, err := c.dispatchAndUnmarshal(ctx, r, "/lol/league/v4/masterleagues/by-queue", fmt.Sprintf("/%s", q.String()), nil, &res)
 	return &res, err
 }
 
 func (c *client) GetLeagueByID(ctx context.Context, r region.Region, leagueID string) (*LeagueList, error) {
 	var res LeagueList
-	_, err := c.dispatchAndUnmarshal(ctx, r, "/lol/league/v3/leagues", fmt.Sprintf("/%s", leagueID), nil, &res)
+	_, err := c.dispatchAndUnmarshal(ctx, r, "/lol/league/v4/leagues", fmt.Sprintf("/%s", leagueID), nil, &res)
 	return &res, err
 }
 
-func (c *client) GetAllLeaguePositionsForSummoner(ctx context.Context, r region.Region, summonerID int64) ([]LeaguePosition, error) {
+func (c *client) GetAllLeaguePositionsForSummoner(ctx context.Context, r region.Region, summonerID string) ([]LeaguePosition, error) {
 	var res []LeaguePosition
-	_, err := c.dispatchAndUnmarshal(ctx, r, "/lol/league/v3/positions/by-summoner", fmt.Sprintf("/%d", summonerID), nil, &res)
+	_, err := c.dispatchAndUnmarshal(ctx, r, "/lol/league/v3/positions/by-summoner", fmt.Sprintf("/%s", summonerID), nil, &res)
 	return res, err
 }

--- a/apiclient/league.go
+++ b/apiclient/league.go
@@ -61,6 +61,12 @@ func (c *client) GetChallengerLeague(ctx context.Context, r region.Region, q que
 	return &res, err
 }
 
+func (c *client) GetGrandmasterLeague(ctx context.Context, r region.Region, q queue.Queue) (*LeagueList, error) {
+	var res LeagueList
+	_, err := c.dispatchAndUnmarshal(ctx, r, "/lol/league/v4/grandmasterleagues/by-queue", fmt.Sprintf("/%s", q.String()), nil, &res)
+	return &res, err
+}
+
 func (c *client) GetMasterLeague(ctx context.Context, r region.Region, q queue.Queue) (*LeagueList, error) {
 	var res LeagueList
 	_, err := c.dispatchAndUnmarshal(ctx, r, "/lol/league/v4/masterleagues/by-queue", fmt.Sprintf("/%s", q.String()), nil, &res)

--- a/apiclient/match.go
+++ b/apiclient/match.go
@@ -19,19 +19,19 @@ import (
 )
 
 type Match struct {
-	SeasonID              season.Season         `datastore:",noindex"`
-	QueueID               queue.Queue           `datastore:",noindex"`
-	GameID                int64                 `datastore:",noindex"`
-	ParticipantIdentities []ParticipantIdentity `datastore:",noindex"`
-	GameVersion           string                `datastore:",noindex"`
-	PlatformID            string                `datastore:",noindex"`
-	GameMode              string                `datastore:",noindex"`
-	MapID                 int                   `datastore:",noindex"`
-	GameType              string                `datastore:",noindex"`
-	Teams                 []TeamStats           `datastore:",noindex"`
-	Participants          []Participant         `datastore:",noindex"`
-	GameDuration          types.Milliseconds    `datastore:",noindex"`
-	GameCreation          types.Milliseconds    `datastore:",noindex"`
+	SeasonID              season.Season         `datastore:",noindex"` // SeasonID is the ID associated with the current season of league.
+	QueueID               queue.Queue           `datastore:",noindex"` // QueueID is a constant that refers to the queue.
+	GameID                int64                 `datastore:",noindex"` // GameID is the ID of the requested game.
+	ParticipantIdentities []ParticipantIdentity `datastore:",noindex"` // Array of player identities in requested game.
+	GameVersion           string                `datastore:",noindex"` // Version that the game was played on.
+	PlatformID            string                `datastore:",noindex"` // PlatformID
+	GameMode              string                `datastore:",noindex"` // GameMode
+	MapID                 int                   `datastore:",noindex"` // MapID is a constant of the map played on.
+	GameType              string                `datastore:",noindex"` // GameType
+	Teams                 []TeamStats           `datastore:",noindex"` // Teams
+	Participants          []Participant         `datastore:",noindex"` // Participants
+	GameDuration          types.Milliseconds    `datastore:",noindex"` // GameDuration is the duration of the game in milliseconds
+	GameCreation          types.Milliseconds    `datastore:",noindex"` // GameCreation is when game was created in epoch
 }
 
 type ParticipantIdentity struct {
@@ -44,10 +44,10 @@ type Player struct {
 	SummonerName      string
 	MatchHistoryUri   string
 	PlatformID        string
-	CurrentAccountID  int64
+	CurrentAccountID  string
 	ProfileIcon       int
-	SummonerID        int64
-	AccountID         int64
+	SummonerID        string
+	AccountID         string
 }
 
 type TeamStats struct {
@@ -315,7 +315,7 @@ func timeToUnixMilliseconds(t time.Time) int64 {
 	return t.UnixNano() / int64(time.Millisecond/time.Nanosecond)
 }
 
-func (c *client) GetMatchlist(ctx context.Context, r region.Region, accountID int64, opts *GetMatchlistOptions) (*Matchlist, error) {
+func (c *client) GetMatchlist(ctx context.Context, r region.Region, accountID string, opts *GetMatchlistOptions) (*Matchlist, error) {
 	var (
 		res  Matchlist
 		vals url.Values
@@ -351,15 +351,15 @@ func (c *client) GetMatchlist(ctx context.Context, r region.Region, accountID in
 			vals.Add("endIndex", fmt.Sprintf("%d", *opts.EndIndex))
 		}
 	}
-	_, err := c.dispatchAndUnmarshal(ctx, r, "/lol/match/v3/matchlists/by-account", fmt.Sprintf("/%d", accountID), vals, &res)
+	_, err := c.dispatchAndUnmarshal(ctx, r, "/lol/match/v4/matchlists/by-account", fmt.Sprintf("/%s", accountID), vals, &res)
 	return &res, err
 }
 
-func (c *client) GetRecentMatchlist(ctx context.Context, r region.Region, accountID int64) (*Matchlist, error) {
+func (c *client) GetRecentMatchlist(ctx context.Context, r region.Region, accountID string) (*Matchlist, error) {
 	var res Matchlist
 	// Recent matchlists are a separate API call from matchlists, even though
 	// both have the same Method. Add "recent" as a uniquifier for this method.
-	_, err := c.dispatchAndUnmarshalWithUniquifier(ctx, r, "/lol/match/v3/matchlists/by-account", fmt.Sprintf("/%d/recent", accountID), nil, "recent", &res)
+	_, err := c.dispatchAndUnmarshalWithUniquifier(ctx, r, "/lol/match/v4/matchlists/by-account", fmt.Sprintf("/%s/recent", accountID), nil, "recent", &res)
 	return &res, err
 }
 
@@ -441,6 +441,6 @@ type MatchEvent struct {
 
 func (c *client) GetMatchTimeline(ctx context.Context, r region.Region, matchID int64) (*MatchTimeline, error) {
 	var res MatchTimeline
-	_, err := c.dispatchAndUnmarshal(ctx, r, "/lol/match/v3/timelines/by-match", fmt.Sprintf("/%d", matchID), nil, &res)
+	_, err := c.dispatchAndUnmarshal(ctx, r, "/lol/match/v4/timelines/by-match", fmt.Sprintf("/%d", matchID), nil, &res)
 	return &res, err
 }

--- a/apiclient/spectator.go
+++ b/apiclient/spectator.go
@@ -41,7 +41,7 @@ type CurrentGameParticipant struct {
 	Spell2Id      int64                              // The ID of the second summoner spell used by this participant
 	Masteries     []CurrentGameParticipantMasteryDTO // The masteries used by this participant
 	Spell1Id      int64                              // The ID of the first summoner spell used by this participant
-	SummonerId    int64                              // The summoner ID of this participant
+	SummonerId    string                             // The encrypted summoner ID of this participant
 	Perks         Perks
 }
 
@@ -61,9 +61,9 @@ type CurrentGameParticipantMasteryDTO struct {
 	Rank      int   // The number of points put into this mastery by the user
 }
 
-func (c *client) GetCurrentGameInfoBySummoner(ctx context.Context, r region.Region, summonerID int64) (*CurrentGameInfo, error) {
+func (c *client) GetCurrentGameInfoBySummoner(ctx context.Context, r region.Region, summonerID string) (*CurrentGameInfo, error) {
 	var res CurrentGameInfo
-	_, err := c.dispatchAndUnmarshal(ctx, r, "/lol/spectator/v3/active-games/by-summoner", fmt.Sprintf("/%d", summonerID), nil, &res)
+	_, err := c.dispatchAndUnmarshal(ctx, r, "/lol/spectator/v4/active-games/by-summoner", fmt.Sprintf("/%s", summonerID), nil, &res)
 	return &res, err
 }
 
@@ -99,6 +99,6 @@ type FeaturedGameParticipantDTO struct {
 
 func (c *client) GetFeaturedGames(ctx context.Context, r region.Region) (*FeaturedGames, error) {
 	var res FeaturedGames
-	_, err := c.dispatchAndUnmarshal(ctx, r, "/lol/spectator/v3/featured-games", "", nil, &res)
+	_, err := c.dispatchAndUnmarshal(ctx, r, "/lol/spectator/v4/featured-games", "", nil, &res)
 	return &res, err
 }

--- a/apiclient/summoner.go
+++ b/apiclient/summoner.go
@@ -9,27 +9,28 @@ import (
 
 type Summoner struct {
 	ProfileIconID int    `datastore:",noindex"` // ID of the summoner icon associated with the summoner.
-	Name          string `datastore:",noindex"` //Summoner name.
+	Name          string `datastore:",noindex"` // Summoner name.
+	PUUID		  string `datastore:",noinex"`  // PUUID is the player universally unique identifier.
 	SummonerLevel int64  `datastore:",noindex"` // Summoner level associated with the summoner.
+	AccountID     string `datastore:",noindex"` // Encrypted account ID.
+	ID            string `datastore:",noindex"` // Encrypted summoner ID.
 	RevisionDate  int64  `datastore:",noindex"` // Date summoner was last modified specified as epoch milliseconds. The following events will update this timestamp: profile icon change, playing the tutorial or advanced tutorial, finishing a game, summoner name change
-	ID            int64  `datastore:",noindex"` // Summoner ID.
-	AccountID     int64  `datastore:",noindex"` //Account ID.
 }
 
-func (c *client) GetByAccountID(ctx context.Context, r region.Region, accountID int64) (*Summoner, error) {
+func (c *client) GetByAccountID(ctx context.Context, r region.Region, accountID string) (*Summoner, error) {
 	var res Summoner
-	_, err := c.dispatchAndUnmarshal(ctx, r, "/lol/summoner/v3/summoners/by-account", fmt.Sprintf("/%d", accountID), nil, &res)
+	_, err := c.dispatchAndUnmarshal(ctx, r, "/lol/summoner/v4/summoners/by-account", fmt.Sprintf("/%s", accountID), nil, &res)
 	return &res, err
 }
 
 func (c *client) GetBySummonerName(ctx context.Context, r region.Region, name string) (*Summoner, error) {
 	var res Summoner
-	_, err := c.dispatchAndUnmarshal(ctx, r, "/lol/summoner/v3/summoners/by-name", fmt.Sprintf("/%s", name), nil, &res)
+	_, err := c.dispatchAndUnmarshal(ctx, r, "/lol/summoner/v4/summoners/by-name", fmt.Sprintf("/%s", name), nil, &res)
 	return &res, err
 }
 
-func (c *client) GetBySummonerID(ctx context.Context, r region.Region, summonerID int64) (*Summoner, error) {
+func (c *client) GetBySummonerID(ctx context.Context, r region.Region, summonerID string) (*Summoner, error) {
 	var res Summoner
-	_, err := c.dispatchAndUnmarshal(ctx, r, "/lol/summoner/v3/summoners", fmt.Sprintf("/%d", summonerID), nil, &res)
+	_, err := c.dispatchAndUnmarshal(ctx, r, "/lol/summoner/v4/summoners", fmt.Sprintf("/%s", summonerID), nil, &res)
 	return &res, err
 }

--- a/apiclient/summoner.go
+++ b/apiclient/summoner.go
@@ -29,6 +29,12 @@ func (c *client) GetBySummonerName(ctx context.Context, r region.Region, name st
 	return &res, err
 }
 
+func (c *client) GetBySummonerPUUID(ctx context.Context, r region.Region, puuid string) (*Summoner, error) {
+	var res Summoner
+	_, err := c.dispatchAndUnmarshal(ctx, r, "/lol/summoner/v4/summoners/by-puuid", fmt.Sprintf("/%s", puuid), nil, &res)
+	return &res, err
+}
+
 func (c *client) GetBySummonerID(ctx context.Context, r region.Region, summonerID string) (*Summoner, error) {
 	var res Summoner
 	_, err := c.dispatchAndUnmarshal(ctx, r, "/lol/summoner/v4/summoners", fmt.Sprintf("/%s", summonerID), nil, &res)

--- a/apiclient/third_party.go
+++ b/apiclient/third_party.go
@@ -7,8 +7,8 @@ import (
 	"github.com/yuhanfang/riot/constants/region"
 )
 
-func (c *client) GetThirdPartyCodeByID(ctx context.Context, r region.Region, summonerID int64) (string, error) {
+func (c *client) GetThirdPartyCodeByID(ctx context.Context, r region.Region, summonerID string) (string, error) {
 	var res string
-	_, err := c.dispatchAndUnmarshal(ctx, r, "/lol/platform/v3/third-party-code/by-summoner", fmt.Sprintf("/%d", summonerID), nil, &res)
+	_, err := c.dispatchAndUnmarshal(ctx, r, "/lol/platform/v4/third-party-code/by-summoner", fmt.Sprintf("/%s", summonerID), nil, &res)
 	return res, err
 }

--- a/cachedclient/cachedclient.go
+++ b/cachedclient/cachedclient.go
@@ -223,7 +223,7 @@ func filterMatchlist(m *apiclient.Matchlist, opts *apiclient.GetMatchlistOptions
 
 func (c *client) GetMatchlist(ctx context.Context, r region.Region, accountID string, opt *apiclient.GetMatchlistOptions) (*apiclient.Matchlist, error) {
 	var val apiclient.Matchlist
-	key := fmt.Sprintf("get-matchlist:%s:%d", r, accountID)
+	key := fmt.Sprintf("get-matchlist:%s:%s", r, accountID)
 	t, err := c.d.Get(ctx, key, &val, time.Now())
 	if err == nil && time.Since(t) < 24*time.Hour {
 		return filterMatchlist(&val, opt), nil
@@ -271,7 +271,7 @@ func (c *client) GetFeaturedGames(ctx context.Context, r region.Region) (*apicli
 
 func (c *client) GetByAccountID(ctx context.Context, r region.Region, accountID string) (*apiclient.Summoner, error) {
 	var val apiclient.Summoner
-	key := fmt.Sprintf("get-by-account-id:%s:%d", r, accountID)
+	key := fmt.Sprintf("get-by-account-id:%s:%s", r, accountID)
 	_, err := c.d.Get(ctx, key, &val, zeroTime)
 	if err == nil {
 		return &val, nil
@@ -302,7 +302,7 @@ func (c *client) GetBySummonerName(ctx context.Context, r region.Region, name st
 
 func (c *client) GetBySummonerID(ctx context.Context, r region.Region, summonerID string) (*apiclient.Summoner, error) {
 	var val apiclient.Summoner
-	key := fmt.Sprintf("get-by-summoner-id:%s:%d", r, summonerID)
+	key := fmt.Sprintf("get-by-summoner-id:%s:%s", r, summonerID)
 	_, err := c.d.Get(ctx, key, &val, zeroTime)
 	if err == nil {
 		return &val, nil

--- a/cachedclient/cachedclient.go
+++ b/cachedclient/cachedclient.go
@@ -106,12 +106,12 @@ func (c *client) GetMasterLeague(ctx context.Context, r region.Region, q queue.Q
 	return res, err
 }
 
-func (c *client) GetAllLeaguePositionsForSummoner(ctx context.Context, r region.Region, summonerID int64) ([]apiclient.LeaguePosition, error) {
+func (c *client) GetAllLeaguePositionsForSummoner(ctx context.Context, r region.Region, summonerID string) ([]apiclient.LeaguePosition, error) {
 	type LeaguePositions struct {
 		Positions []apiclient.LeaguePosition
 	}
 	var val LeaguePositions
-	key := fmt.Sprintf("get-all-league-positions-for-summoner:%s:%d", r, summonerID)
+	key := fmt.Sprintf("get-all-league-positions-for-summoner:%s:%s", r, summonerID)
 	t, err := c.d.Get(ctx, key, &val, time.Now())
 	if err == nil && time.Since(t) < 24*time.Hour {
 		return val.Positions, nil
@@ -221,7 +221,7 @@ func filterMatchlist(m *apiclient.Matchlist, opts *apiclient.GetMatchlistOptions
 	return &res
 }
 
-func (c *client) GetMatchlist(ctx context.Context, r region.Region, accountID int64, opt *apiclient.GetMatchlistOptions) (*apiclient.Matchlist, error) {
+func (c *client) GetMatchlist(ctx context.Context, r region.Region, accountID string, opt *apiclient.GetMatchlistOptions) (*apiclient.Matchlist, error) {
 	var val apiclient.Matchlist
 	key := fmt.Sprintf("get-matchlist:%s:%d", r, accountID)
 	t, err := c.d.Get(ctx, key, &val, time.Now())
@@ -237,9 +237,9 @@ func (c *client) GetMatchlist(ctx context.Context, r region.Region, accountID in
 	return filterMatchlist(res, opt), err
 }
 
-func (c *client) GetRecentMatchlist(ctx context.Context, r region.Region, accountID int64) (*apiclient.Matchlist, error) {
+func (c *client) GetRecentMatchlist(ctx context.Context, r region.Region, accountID string) (*apiclient.Matchlist, error) {
 	var val apiclient.Matchlist
-	key := fmt.Sprintf("get-recent-matchlist:%s:%d", r, accountID)
+	key := fmt.Sprintf("get-recent-matchlist:%s:%s", r, accountID)
 	t, err := c.d.Get(ctx, key, &val, time.Now())
 	if err == nil && time.Since(t) < 1*time.Hour {
 		return &val, nil
@@ -269,7 +269,7 @@ func (c *client) GetFeaturedGames(ctx context.Context, r region.Region) (*apicli
 	return res, err
 }
 
-func (c *client) GetByAccountID(ctx context.Context, r region.Region, accountID int64) (*apiclient.Summoner, error) {
+func (c *client) GetByAccountID(ctx context.Context, r region.Region, accountID string) (*apiclient.Summoner, error) {
 	var val apiclient.Summoner
 	key := fmt.Sprintf("get-by-account-id:%s:%d", r, accountID)
 	_, err := c.d.Get(ctx, key, &val, zeroTime)
@@ -300,7 +300,7 @@ func (c *client) GetBySummonerName(ctx context.Context, r region.Region, name st
 	return res, err
 }
 
-func (c *client) GetBySummonerID(ctx context.Context, r region.Region, summonerID int64) (*apiclient.Summoner, error) {
+func (c *client) GetBySummonerID(ctx context.Context, r region.Region, summonerID string) (*apiclient.Summoner, error) {
 	var val apiclient.Summoner
 	key := fmt.Sprintf("get-by-summoner-id:%s:%d", r, summonerID)
 	_, err := c.d.Get(ctx, key, &val, zeroTime)

--- a/examples/example_apiclient/example_apiclient.go
+++ b/examples/example_apiclient/example_apiclient.go
@@ -19,9 +19,9 @@ import (
 )
 
 const (
-	playerID = 84289964
+	playerID = "x9k0laU59wtIYnd8zt1dZmtJ_wXl13bqjhTRRC8FPwTbYVA" // These are encrypted per the api key used
 	name     = "waddlechirp"
-	account  = 237254272
+	account  = "hJN7Yl1FSZLD4vGKUIAMVFI_IWqK7WmY6Lb9S2QGRSUes8U" // These are encrypted per the api key used
 	game     = 2644987649
 	league   = "6b5c7950-5260-11e7-8125-c81f66dbb56c"
 	reg      = region.NA1

--- a/examples/example_cachedclient/example_cachedclient.go
+++ b/examples/example_cachedclient/example_cachedclient.go
@@ -21,9 +21,9 @@ import (
 )
 
 const (
-	playerID = 84289964
+	playerID = "x9k0laU59wtIYnd8zt1dZmtJ_wXl13bqjhTRRC8FPwTbYVA" // These are encrypted per the api key used
 	name     = "waddlechirp"
-	account  = 237254272
+	account  = "hJN7Yl1FSZLD4vGKUIAMVFI_IWqK7WmY6Lb9S2QGRSUes8U" // These are encrypted per the api key used
 	game     = 2644987649
 	league   = "6b5c7950-5260-11e7-8125-c81f66dbb56c"
 	reg      = region.NA1


### PR DESCRIPTION
This pr will replace all the applicable endpoints with the new v4 endpoints. 

Changes:
* AccountID/SummonerID are no longer int64 numbers and are now encrypted (strings).
* Getting a summoner will now return PUUID.
* You are also able to get a summoner by PUUID (new endpoint).
* Grandmaster has been added (also in v3)

This probably doesn't need to/shouldn't be merged to master yet, until v3 is deprecated (January 28th, 2019) as it is breaking changes.