### PR TITLE
Added ability to get single champion from riot with full details

### DIFF
--- a/staticdata/champions.go
+++ b/staticdata/champions.go
@@ -165,11 +165,11 @@ type SpellLevelTip struct {
 }
 
 type SpellVars struct {
-	RanksWith string  `json:"ranksWith"`
-	Dyn       string  `json:"dyn"`
-	Link      string  `json:"link"`
-	Coeff     float64 `json:"coeff"`
-	Key       string  `json:"key"`
+	RanksWith string      `json:"ranksWith"`
+	Dyn       string      `json:"dyn"`
+	Link      string      `json:"link"`
+	Coeff     interface{} `json:"coeff"`
+	Key       string      `json:"key"`
 }
 
 func (c *Client) Champions(ctx context.Context, v Version, lang language.Language) (*ChampionList, error) {
@@ -177,4 +177,12 @@ func (c *Client) Champions(ctx context.Context, v Version, lang language.Languag
 	var champList ChampionList
 	err := c.getJSON(ctx, url, &champList)
 	return &champList, err
+}
+
+func (c *Client) Champion(ctx context.Context, v Version, lang language.Language, championName string) (*Champion, error) {
+	url := fmt.Sprintf("http://ddragon.leagueoflegends.com/cdn/%s/data/%s/champion/%s.json", v, lang, championName)
+	var champList ChampionList
+	err := c.getJSON(ctx, url, &champList)
+	champ := champList.Data[championName]
+	return &champ, err
 }


### PR DESCRIPTION
Added function to get full (single) champion details.

Updated "Coeff" to interface because sometimes riot gives us a float64 for that, sometimes an array of float64.

Example1:
"coeff":[0.6,0.75,0.9,1.05,1.2]
Example2: 
"coeff":0.9

Source: http://ddragon.leagueoflegends.com/cdn/9.19.1/data/en_US/champion/Lucian.json